### PR TITLE
fix: Run workflow on merge to main, small fix in plugin.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,8 @@ name: goreleaser
 
 on:
   push:
-    tags:
-      - "*"
+    branches:
+      - "main"
 
 jobs:
   goreleaser:

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: "schema-gen"
-version: "0.0.4"
+version: "0.0.1"
 usage: "generate json schema for values yaml"
 description: "generate json schema for values yaml"
 command: "$HELM_PLUGIN_DIR/bin/helm-schema-gen"


### PR DESCRIPTION
This pull request includes significant updates to the `helm-schema-gen` project, focusing on updating dependencies, modifying build configurations, and making code improvements. The most important changes are summarized below:

### Workflow and Build Configuration Updates:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L5-R6): Changed the trigger for the release workflow from tags to the `main` branch.

### Project Metadata Updates:

* [`plugin.yaml`](diffhunk://#diff-d55bf51ed4d80c9c0eef853d64823da5d91fad2e860465f50b40c355fd307afaL2-R2): Reset the plugin version from `0.0.4` to `0.0.1`.
* [`scripts/install_version.sh`](diffhunk://#diff-d99fb28a976ed2b420bd55d826fa6e3a16710c73b2e9d9079962322c0ca9443dL10-R10): Updated the script to install version `0.0.1` instead of `0.0.4`.