### PR TITLE
fix: Change --rm-dist to --clean in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,6 +60,6 @@ jobs:
         uses: goreleaser/goreleaser-action@v4
         with:
           version: latest
-          args: release --rm-dist
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change modifies the `args` parameter in the `goreleaser` action to use the `--clean` flag instead of `--rm-dist` for the release process.