### PR TITLE
fix: Fetch tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Set up Go
         uses: actions/setup-go@v3


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yml` file. The change ensures that tags are fetched during the checkout step in the release workflow.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R52): Added `fetch-tags: true` to the `uses: actions/checkout@v3` step to ensure tags are fetched.