### PR TITLE
fix: Split workflows

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,0 +1,36 @@
+name: GoReleaser
+
+on:
+  push:
+    tags:
+      - "v*"
+
+
+permissions:
+  contents: write
+  # packages: write
+  # issues: write
+  # id-token: write
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: stable
+          
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,29 +38,4 @@ jobs:
       - name: Semantic Release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release
-
-  build:
-    needs: release
-    name: Build Release
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-
-      - name: Set up Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.24.1'
-          check-latest: true
-
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
-        with:
-          version: latest
-          args: release --clean
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 
+        run: semantic-release 


### PR DESCRIPTION
This pull request includes changes to the GitHub workflows to improve the release process by introducing a new GoReleaser workflow and removing redundant steps from the existing release workflow.

Changes to GitHub workflows:

* Added a new `GoReleaser` workflow in `.github/workflows/goreleaser.yml` to automate the release process using GoReleaser.
* Removed the redundant `build` job from the `.github/workflows/release.yml` file, which previously handled the GoReleaser steps.