### PR TITLE
fix: Trigger GoRelease after Semantic Release workflow

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,16 +1,12 @@
 name: GoReleaser
 
 on:
-  push:
-    tags:
-      - "v*"
+  repository_dispatch:
+    types: [goreleaser]
 
 
 permissions:
   contents: write
-  # packages: write
-  # issues: write
-  # id-token: write
 
 jobs:
   goreleaser:
@@ -20,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'repository_dispatch' && format('v{0}', github.event.client_payload.version) || '' }}
 
       - name: Set up Go
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   release:
     name: Semantic Release
     runs-on: ubuntu-latest
+    outputs:
+      new_release_published: ${{ steps.semantic.outputs.new_release_published }}
+      new_release_version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -36,6 +39,16 @@ jobs:
           chmod +x /usr/local/bin/yq
 
       - name: Semantic Release
+        id: semantic
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: semantic-release 
+        run: semantic-release
+        
+      - name: Trigger GoReleaser workflow
+        if: steps.semantic.outputs.new_release_published == 'true'
+        run: |
+          curl -XPOST \
+            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            -H "Accept: application/vnd.github.v3+json" \
+            https://api.github.com/repos/${{ github.repository }}/dispatches \
+            -d '{"event_type": "goreleaser", "client_payload": {"version": "${{ steps.semantic.outputs.new_release_version }}"}}' 


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflows to enhance the release process. The most important changes include switching the GoReleaser workflow trigger to `repository_dispatch`, adding outputs to the Semantic Release job, and triggering the GoReleaser workflow upon a new release.

Enhancements to GitHub Actions workflows:

* [`.github/workflows/goreleaser.yml`](diffhunk://#diff-7be83bb2bf927f774c15a8aaefef2239c923755f8a8137418d10295361ec3f17L4-L13): Changed the trigger from `push` to `repository_dispatch` and added a condition to set the `ref` during checkout. [[1]](diffhunk://#diff-7be83bb2bf927f774c15a8aaefef2239c923755f8a8137418d10295361ec3f17L4-L13) [[2]](diffhunk://#diff-7be83bb2bf927f774c15a8aaefef2239c923755f8a8137418d10295361ec3f17R19)
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R12-R14): Added outputs to the Semantic Release job and included a step to trigger the GoReleaser workflow if a new release is published. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R12-R14) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R42-R54)