### PR TITLE
fix: GoRelease Trigger

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+  
 jobs:
   release:
     name: Semantic Release
@@ -45,10 +49,23 @@ jobs:
         run: semantic-release
         
       - name: Trigger GoReleaser workflow
-        if: steps.semantic.outputs.new_release_published == 'true'
+        if: success()
         run: |
-          curl -XPOST \
-            -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-            -H "Accept: application/vnd.github.v3+json" \
-            https://api.github.com/repos/${{ github.repository }}/dispatches \
-            -d '{"event_type": "goreleaser", "client_payload": {"version": "${{ steps.semantic.outputs.new_release_version }}"}}' 
+          # Check if a new release was published by looking for the tag
+          if git show-ref --tags | grep -q "refs/tags/v"; then
+            NEW_TAG=$(git describe --tags --abbrev=0)
+            echo "New tag detected: $NEW_TAG"
+            # Extract version without v prefix
+            VERSION=${NEW_TAG#v}
+            
+            # Trigger the repository dispatch event
+            curl -XPOST \
+              -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+              -H "Accept: application/vnd.github.v3+json" \
+              https://api.github.com/repos/${{ github.repository }}/dispatches \
+              -d "{\"event_type\": \"goreleaser\", \"client_payload\": {\"version\": \"${VERSION}\"}}"
+            
+            echo "Triggered GoReleaser workflow for version $VERSION"
+          else
+            echo "No new tag detected, skipping GoReleaser trigger"
+          fi


### PR DESCRIPTION
This pull request includes updates to the release workflow configuration in `.github/workflows/release.yml`. The changes primarily focus on enhancing permissions and improving the logic for triggering the GoReleaser workflow.

Enhancements to workflow permissions and logic:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R8-R11): Added `permissions` section to grant write access to contents and pull-requests.
* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L48-R71): Modified the condition to trigger the GoReleaser workflow to use `success()` and added logic to check for new tags before triggering the repository dispatch event.