### PR TITLE
fix: Change script name

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,10 +5,10 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       ["@semantic-release/exec", {
-        "prepareCmd": "./scripts/install_version.sh \\${nextRelease.version}"
+        "prepareCmd": "./scripts/set_version.sh \\${nextRelease.version}"
       }],
       ["@semantic-release/git", {
-        "assets": ["plugin.yaml", "scripts/install_version.sh", "CHANGELOG.md"],
+        "assets": ["plugin.yaml", "scripts/set_version.sh", "CHANGELOG.md"],
         "message": "chore(release): \\${nextRelease.version} [skip ci]\\n\\n\\${nextRelease.notes}"
       }],
       "@semantic-release/github"


### PR DESCRIPTION
This pull request includes a change to the `.releaserc.json` file, specifically updating the script used for setting the version during the release process.

Changes to release configuration:

* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L8-R11): Updated the `prepareCmd` to use `set_version.sh` instead of `install_version.sh` and adjusted the assets list accordingly.