### PR TITLE
fix: Substitution error while triggering script

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -5,7 +5,7 @@
       "@semantic-release/release-notes-generator",
       "@semantic-release/changelog",
       ["@semantic-release/exec", {
-        "prepareCmd": "./scripts/set_version.sh \\${nextRelease.version}"
+        "prepareCmd": "./scripts/set_version.sh ${nextRelease.version}"
       }],
       ["@semantic-release/git", {
         "assets": ["plugin.yaml", "scripts/set_version.sh", "CHANGELOG.md"],


### PR DESCRIPTION
This pull request includes a minor update to the `.releaserc.json` file. The change involves removing an unnecessary escape character in the `prepareCmd` script command.

* [`.releaserc.json`](diffhunk://#diff-e774e90e159e39c0a392fffa584ea8520508a9a0c10468d0bd685800e28a42f5L8-R8): Removed the unnecessary escape character before `nextRelease.version` in the `prepareCmd` script command.