### PR TITLE
fix: Set Version Script POSIX compliant

### DIFF
--- a/scripts/set_version.sh
+++ b/scripts/set_version.sh
@@ -8,9 +8,10 @@
 VERSION=${1:-"v1.1.5"}
 
 # If VERSION doesn't start with 'v', add it
-if [ "${VERSION:0:1}" != "v" ]; then
-  VERSION="v$VERSION"
-fi
+case "$VERSION" in
+  v*) ;;
+  *) VERSION="v$VERSION" ;;
+esac
 
 # Update plugin.yaml version
 if command -v yq >/dev/null 2>&1; then


### PR DESCRIPTION
This pull request includes a small change to the `scripts/set_version.sh` file. The change replaces an `if` statement with a `case` statement to handle the version prefix check more concisely.

* [`scripts/set_version.sh`](diffhunk://#diff-5d53315446330c949d6008adb306b9d8e74a2379a80e8b717b1ad106cf51715bL11-R14): Replaced the `if` statement with a `case` statement to check if the `VERSION` variable starts with 'v'.